### PR TITLE
Add profile-specific configuration and test coverage

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,10 @@
+spring.jpa.generate-ddl=true
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.data-locations=classpath:sql/data.sql
+spring.sql.init.mode=always
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.username=robert
+spring.datasource.password=BM123
+spring.datasource.url=jdbc:postgresql://localhost:5433/budgetmate

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,12 +2,7 @@ server.port=8089
 spring.application.name=BudgetMateApp
 spring.application.url=http://app.budgetmate.com
 
-spring.jpa.generate-ddl=true
-spring.jpa.hibernate.ddl-auto=create
-spring.jpa.defer-datasource-initialization=true
 spring.jpa.open-in-view=false
-spring.sql.init.data-locations=classpath:sql/data.sql
-spring.sql.init.mode=always
 
 server.forward-headers-strategy=framework
 server.error.path=/error
@@ -16,9 +11,3 @@ logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=ERROR
 
 brevo.api.key=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
-
-spring.datasource.driver-class-name=org.postgresql.Driver
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-spring.datasource.username=robert
-spring.datasource.password=BM123
-spring.datasource.url=jdbc:postgresql://localhost:5433/budgetmate

--- a/src/test/java/budgetMate/api/api/accounts/service/AccountServiceIntegrationTest.java
+++ b/src/test/java/budgetMate/api/api/accounts/service/AccountServiceIntegrationTest.java
@@ -1,0 +1,103 @@
+package budgetMate.api.api.accounts.service;
+
+import budgetMate.api.domain.Account;
+import budgetMate.api.domain.Record;
+import budgetMate.api.domain.User;
+import budgetMate.api.domain.enums.AccountType;
+import budgetMate.api.domain.enums.Currency;
+import budgetMate.api.domain.enums.RecordType;
+import budgetMate.api.domain.enums.Role;
+import budgetMate.api.repository.AccountRepository;
+import budgetMate.api.repository.RecordRepository;
+import budgetMate.api.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class AccountServiceIntegrationTest {
+
+    @Autowired
+    private AccountService accountService;
+    @Autowired
+    private AccountRepository accountRepository;
+    @Autowired
+    private RecordRepository recordRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user1;
+    private User user2;
+    private Account account;
+
+    @BeforeEach
+    void init() {
+        recordRepository.deleteAll();
+        accountRepository.deleteAll();
+        userRepository.deleteAll();
+
+        user1 = User.builder().username("user1@test.com").password("pass").role(Role.USER).build();
+        user2 = User.builder().username("user2@test.com").password("pass").role(Role.USER).build();
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        account = Account.builder()
+                .name("Wallet")
+                .currency(Currency.USD)
+                .currentBalance(50)
+                .type(AccountType.CASH)
+                .createdBy(user1)
+                .build();
+        accountRepository.save(account);
+        accountRepository.addUserAccountAssociation(user1.getId(), account.getId());
+    }
+
+    private HttpServletRequest requestFor(User user) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setUserPrincipal(() -> user.getUsername());
+        return request;
+    }
+
+    @Test
+    void deleteAccount_whenNoOtherAssociations_removesAccountAndRecords() {
+        Record record = Record.builder()
+                .amount(10)
+                .currency(Currency.USD)
+                .type(RecordType.EXPENSE)
+                .user(user1)
+                .withdrawalAccount(account)
+                .build();
+        recordRepository.save(record);
+
+        accountService.deleteUserAccount(requestFor(user1), account.getId());
+
+        assertThat(accountRepository.findById(account.getId())).isEmpty();
+        assertThat(recordRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void deleteAccount_whenStillShared_onlyRemovesAssociationAndRecords() {
+        accountRepository.addUserAccountAssociation(user2.getId(), account.getId());
+        Record record = Record.builder()
+                .amount(20)
+                .currency(Currency.USD)
+                .type(RecordType.EXPENSE)
+                .user(user1)
+                .withdrawalAccount(account)
+                .build();
+        recordRepository.save(record);
+
+        accountService.deleteUserAccount(requestFor(user1), account.getId());
+
+        assertThat(accountRepository.findById(account.getId())).isPresent();
+        assertThat(accountRepository.countUserAccountAssociations(account.getId())).isEqualTo(1);
+        assertThat(recordRepository.findAll()).isEmpty();
+    }
+}

--- a/src/test/java/budgetMate/api/api/auth/AuthControllerIntegrationTest.java
+++ b/src/test/java/budgetMate/api/api/auth/AuthControllerIntegrationTest.java
@@ -1,0 +1,58 @@
+package budgetMate.api.api.auth;
+
+import budgetMate.api.domain.User;
+import budgetMate.api.domain.enums.Role;
+import budgetMate.api.producer.EmailProducer;
+import budgetMate.api.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuthControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UserRepository userRepository;
+    @MockBean
+    private EmailProducer emailProducer;
+
+    @BeforeEach
+    void setup() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void registerNewUser_returnsCreated() throws Exception {
+        mockMvc.perform(post("/api/v2/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"firstname\":\"John\",\"lastname\":\"Doe\",\"email\":\"john@example.com\",\"password\":\"pwd\",\"receiveNewsLetters\":true}"))
+                .andExpect(status().isCreated());
+
+        assertThat(userRepository.findUserByUsername("john@example.com")).isPresent();
+    }
+
+    @Test
+    void registerExistingUser_returnsNotFound() throws Exception {
+        User existing = User.builder().username("jane@example.com").password("pwd").role(Role.USER).isEnabled(true).build();
+        userRepository.save(existing);
+
+        mockMvc.perform(post("/api/v2/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"firstname\":\"Jane\",\"lastname\":\"Doe\",\"email\":\"jane@example.com\",\"password\":\"pwd\",\"receiveNewsLetters\":false}"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/budgetMate/api/api/auth/service/AuthServiceTest.java
+++ b/src/test/java/budgetMate/api/api/auth/service/AuthServiceTest.java
@@ -1,0 +1,114 @@
+package budgetMate.api.api.auth.service;
+
+import budgetMate.api.api.auth.request.RegistrationRequest;
+import budgetMate.api.domain.EmailAuthToken;
+import budgetMate.api.domain.User;
+import budgetMate.api.producer.EmailProducer;
+import budgetMate.api.repository.EmailAuthTokenRepository;
+import budgetMate.api.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private EmailAuthTokenRepository emailAuthTokenRepository;
+    @Mock
+    private AuthenticationManager authManager;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private EmailProducer emailProducer;
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    private RegistrationRequest registrationRequest;
+
+    @BeforeEach
+    void setUp() {
+        registrationRequest = new RegistrationRequest("John", "Doe", "john@test.com", "pwd", true);
+    }
+
+    @Test
+    void register_existingEnabledUser_throwsException() {
+        User existing = User.builder().username("john@test.com").isEnabled(true).build();
+        when(userRepository.findUserByUsername("john@test.com")).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> authService.register(registrationRequest))
+                .isInstanceOf(IllegalStateException.class);
+
+        verify(userRepository, never()).save(any());
+        verify(emailAuthTokenRepository, never()).save(any());
+    }
+
+    @Test
+    void register_newUser_savesUserAndToken() {
+        when(userRepository.findUserByUsername("john@test.com")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("pwd")).thenReturn("enc");
+
+        authService.register(registrationRequest);
+
+        verify(userRepository).save(any(User.class));
+        verify(emailAuthTokenRepository).save(any(EmailAuthToken.class));
+        verify(emailProducer).sendConfirmationEmail(any(), any());
+    }
+
+    @Test
+    void confirmRegister_tokenNotFound_throwsException() {
+        UUID token = UUID.randomUUID();
+        when(emailAuthTokenRepository.getUserEmailAuthToken(token, "john@test.com"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.confirmRegister("john@test.com", token.toString()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void confirmRegister_tokenExpired_throwsException() {
+        UUID token = UUID.randomUUID();
+        EmailAuthToken authToken = EmailAuthToken.builder()
+                .token(token)
+                .user(new User())
+                .createdAt(LocalDateTime.now().minusMinutes(31))
+                .build();
+        when(emailAuthTokenRepository.getUserEmailAuthToken(token, "john@test.com"))
+                .thenReturn(Optional.of(authToken));
+
+        assertThatThrownBy(() -> authService.confirmRegister("john@test.com", token.toString()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void confirmRegister_validToken_marksCheckedAndEnablesUser() {
+        UUID token = UUID.randomUUID();
+        EmailAuthToken authToken = EmailAuthToken.builder()
+                .token(token)
+                .user(new User())
+                .createdAt(LocalDateTime.now())
+                .build();
+        when(emailAuthTokenRepository.getUserEmailAuthToken(token, "john@test.com"))
+                .thenReturn(Optional.of(authToken));
+
+        authService.confirmRegister("john@test.com", token.toString());
+
+        verify(emailAuthTokenRepository).setEmailAuthTokenAsChecked(token);
+        verify(userRepository).enableUser("john@test.com");
+    }
+}

--- a/src/test/java/budgetMate/api/api/recordCategories/RecordCategoriesControllerTest.java
+++ b/src/test/java/budgetMate/api/api/recordCategories/RecordCategoriesControllerTest.java
@@ -1,0 +1,48 @@
+package budgetMate.api.api.recordCategories;
+
+import budgetMate.api.api.recordCategories.service.RecordCategoriesService;
+import budgetMate.api.domain.RecordCategory;
+import budgetMate.api.util.HttpUtil;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RecordCategoriesController.class)
+class RecordCategoriesControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private RecordCategoriesService recordCategoriesService;
+    @MockBean
+    private HttpUtil httpUtil;
+
+    @Test
+    void getRecordCategories_returnsOk() throws Exception {
+        List<RecordCategory> categories = List.of(new RecordCategory());
+        when(recordCategoriesService.getRecordCategories()).thenReturn(categories);
+        when(httpUtil.handleGet(categories)).thenReturn(ResponseEntity.ok(categories));
+
+        mockMvc.perform(get("/api/v1/record-categories"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void getRecordCategories_returnsNoContent() throws Exception {
+        when(recordCategoriesService.getRecordCategories()).thenReturn(null);
+        when(httpUtil.handleGet(Mockito.<List<RecordCategory>>any())).thenReturn(ResponseEntity.noContent().build());
+
+        mockMvc.perform(get("/api/v1/record-categories"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/budgetMate/api/repository/AccountRepositoryTest.java
+++ b/src/test/java/budgetMate/api/repository/AccountRepositoryTest.java
@@ -1,0 +1,69 @@
+package budgetMate.api.repository;
+
+import budgetMate.api.domain.Account;
+import budgetMate.api.domain.User;
+import budgetMate.api.domain.enums.AccountType;
+import budgetMate.api.domain.enums.Currency;
+import budgetMate.api.domain.enums.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class AccountRepositoryTest {
+
+    @Autowired
+    private AccountRepository accountRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .username("repo@test.com")
+                .password("pass")
+                .role(Role.USER)
+                .build();
+        userRepository.save(user);
+    }
+
+    @Test
+    void deletingUser_shouldAlsoDeleteAccounts() {
+        Account account = Account.builder()
+                .name("Main")
+                .currency(Currency.USD)
+                .currentBalance(10)
+                .type(AccountType.CASH)
+                .createdBy(user)
+                .build();
+        accountRepository.save(account);
+
+        assertThat(accountRepository.findAll()).hasSize(1);
+
+        userRepository.delete(user);
+
+        assertThat(accountRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void savingAccountWithoutRequiredName_shouldFail() {
+        Account account = Account.builder()
+                .currency(Currency.USD)
+                .currentBalance(5)
+                .type(AccountType.CASH)
+                .createdBy(user)
+                .build();
+
+        assertThrows(DataIntegrityViolationException.class,
+                () -> accountRepository.saveAndFlush(account));
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;DATABASE_TO_UPPER=false
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.defer-datasource-initialization=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.sql.init.mode=never


### PR DESCRIPTION
## Summary
- Separate dev and test database profiles to isolate seed data
- Add repository and service integration tests for account lifecycle
- Add REST controller integration tests and unit tests with Mockito
- Cover AuthService registration and confirmation logic with unit tests

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies from Maven Central, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6c991988832c89d28a0a3b51ba68